### PR TITLE
Got restructure to work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+server/resources

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -6,9 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login</title>
   <!-- CSS Link -->
-  <link rel="stylesheet" href="dist/styles.css" type="text/css">
-    <!-- Styles -->
-    <link rel="stylesheet" href="{{ asset('dist/styles.css') }}">
+  @vite('resources/dist/styles.css')
+  <script src="https://kit.fontawesome.com/84e2199ce0.js" crossorigin="anonymous"></script>
 </head>
 <body>
   <div class="login">
@@ -19,7 +18,7 @@
     <div class="group">
 
     </div>
-    <?php include('layouts.components.messages.short.short') ?>
+    @include('layouts.components.messages.short.short')
     <form action="" method="" class="modify hero">
       <div class="login-details">
         <span class="title">Sign in</span>
@@ -39,7 +38,7 @@
         <button class="primary">Sign in</button>
       </div>
     </form>
-    @include('inc/footer.php');
+    @include('layouts.inc.footer')
     </div>
   </div>
 </body>

--- a/resources/views/layouts/components/modals.blade.php
+++ b/resources/views/layouts/components/modals.blade.php
@@ -5,7 +5,7 @@
         <i class="fa-solid fa-xmark"></i>
       </button>
     </div>
-    <img src="{{ assets('assets/images/throw_away.svg') }}" alt="Throw Away Item">
+    <img src="assets/images/throw_away.svg" alt="Throw Away Item">
     <div class="group">
       <span class="title">You are about to delete this row.</span>
       <span class="description">If you delete this row data,  you can't recover it.</span>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -11,7 +11,7 @@
     <title>@yield('title')</title>
 
     <!-- Styles -->
-    <link rel="stylesheet" href="{{ asset('dist/styles.css') }}">
+    @vite('resources/dist/styles.css')
 
     <!-- Scripts -->
     <script src="https://use.fontawesome.com/releases/v6.1.0/js/all.js" crossorigin="anonymous"></script>
@@ -23,9 +23,9 @@
   <div class="page">
     <div class="page__header">
 
-      @include('layouts.inc.navbar');
-      @include('components.menus');
-      @include('components.modals');
+      @include('layouts.inc.header');
+      @include('layouts.components.menus');
+      @include('layouts.components.modals');
 
       
     </div>
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-    <script src="{{ asset('assets/js/main.js') }}"></script>
+  @vite('resources/js/main.js')
 </body>
 
 </html>

--- a/server/app/Http/Controllers/MasterlistController.php
+++ b/server/app/Http/Controllers/MasterlistController.php
@@ -9,7 +9,7 @@ use Illuminate\Http\Request;
 class MasterlistController extends Controller
 {
     public function index() {
-        return view('master-list', [
+        return view('frontend.master-list.index', [
             'students' => Student::paginate(10),
         ]);
     }

--- a/server/routes/web.php
+++ b/server/routes/web.php
@@ -17,10 +17,10 @@ use Illuminate\Support\Facades\Route;
 // This file is empty since no web routes are used;
 // views are defined in the folders 'client/' and 'mobile/'
 
-Route::get('/', fn () => view('index'));
+Route::get('/', fn () => view('auth.login'));
 
 Route::controller(MasterlistController::class)
-    ->prefix('masterlist')
+    ->prefix('master-list')
     ->group(function () {
         Route::get('/', 'index');
     });


### PR DESCRIPTION
The restructure did not work off the bat. I had to symlink the resources folder inside the server to work. Then, had to change the way assets are served since it does not seem that the use of the {{ asset() }} directive is supported anymore, instead using @vite as per [this page of the Laravel documentation](https://laravel.com/docs/10.x/vite). Besides that, everything still seems to work as intended.

On continuing this branch, note however that while API routes are there, the web routes are not yet there. Setting up a test route would do for the time being.